### PR TITLE
Scale down cms to 0 instances

### DIFF
--- a/deploy/modules/container-app-cms.bicep
+++ b/deploy/modules/container-app-cms.bicep
@@ -131,7 +131,7 @@ resource containerApp 'Microsoft.App/containerApps@2023-08-01-preview' = {
         }
       ]
       scale: {
-        minReplicas: 1
+        minReplicas: 0
         maxReplicas: 1
       }
     }


### PR DESCRIPTION
This pull request updates the scale configuration for the cms resource in order to scale it down to 0 instances. This change is necessary to optimize resource allocation and reduce costs.